### PR TITLE
Add fly.io deploy docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/.env
+fly.toml

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ fly secrets set $(cat .env | xargs)
 Deploy your app to Fly:
 
 ```bash
-fly deploy
+fly deploy --ha=false
 ```
 
 This command will use the `fly.toml` file in the project directory to configure and deploy the app.
@@ -99,10 +99,16 @@ This command will use the `fly.toml` file in the project directory to configure 
 To make it easier to connect to your Postgres instance, allocate a shared IPv4 address:
 
 ```bash
-fly ips allocate-v4 --shared
+fly ips allocate-v6
 ```
 
-This command allocates a shared IPv4 address that you can use to connect to your Postgres instance.
+This command allocates an IPv4 address that you can use to connect to your Postgres instance.
+Note: If you require an IPv4 address and your client doesn't support IPv6, you can allocate a dedicated IPv4 address. However, be aware that this will incur a cost of $2 per month:
+
+```bash
+fly ips allocate-v4
+```
+
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ fly deploy --ha=false
 
 This command will use the `fly.toml` file in the project directory to configure and deploy the app.
 
-### Step 4: Allocate a shared IPv4 address
+### Step 4: Allocate an IP address
 
-To make it easier to connect to your Postgres instance, allocate a shared IPv4 address:
+To make it easier to connect to your Postgres instance, allocate an IP address:
 
 ```bash
 fly ips allocate-v6

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To make it easier to connect to your Postgres instance, allocate a shared IPv4 a
 fly ips allocate-v6
 ```
 
-This command allocates an IPv4 address that you can use to connect to your Postgres instance.
+This command allocates an IPv6 address that you can use to connect to your Postgres instance.
 Note: If you require an IPv4 address and your client doesn't support IPv6, you can allocate a dedicated IPv4 address. However, be aware that this will incur a cost of $2 per month:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,13 +64,51 @@ After this, you the Oriole background workers will store the data in Tigris. You
 
 ## Deploy to Fly
 
-TBD
+To deploy your Serverless Postgres to Fly.io, follow these steps:
+
+### Step 1: Create a new Fly app
+
+Create a new Fly app for your Serverless Postgres:
+
+```bash
+fly apps create your-serverless-postgres
+```
+
+Replace `your-serverless-postgres` with your desired app name.
+
+### Step 2: Create secrets
+
+First, create secrets for your Tigris credentials:
+
+```bash
+fly secrets set $(cat .env | xargs)
+```
+
+### Step 3: Deploy to Fly
+
+Deploy your app to Fly:
+
+```bash
+fly deploy
+```
+
+This command will use the `fly.toml` file in the project directory to configure and deploy the app.
+
+### Step 4: Allocate a shared IPv4 address
+
+To make it easier to connect to your Postgres instance, allocate a shared IPv4 address:
+
+```bash
+fly ips allocate-v4 --shared
+```
+
+This command allocates a shared IPv4 address that you can use to connect to your Postgres instance.
 
 ## Roadmap
 
 I wouldn't recommend using this in production just yet. The goal of this repo is to showcase Oriole and start gathering feedback from anyone who wants to test it out. Please submit any Oriole bug reports to the [Oriole GitHub repo](https://github.com/orioledb/orioledb).
 
-- [ ] **Deploy to Fly**. I still need to document the secure deployment steps for Fly.io (PRs welcome).
+- [x] **Deploy to Fly**. Documentation for secure deployment steps for Fly.io has been added.
 - [ ] **Distributed read replicas**. Oriole can have many read-replicas reading from the same S3 bucket. This is a good pairing with Fly.io that makes it simple to launch servers around the world. Not that if you do this it's _very important_ that the read replicas do not write to the same bucket as your primary or the data will become corrupted.
 - [x] **Distributed data, without Postgres replication**. ~~Tigris will globally replicate objects that are less that 128 bytes. We would need to support global replication of all objects in this bucket if we want to create fast read replicas without Postgres replication.~~
   - Tigris replicates any object that requires fast access regardless of the size. It is possible to [control this per object](https://www.tigrisdata.com/docs/objects/object_regions/). I need to test this implementation but it should work "in theory".

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+app = 'your-serverless-postgres'
+primary_region = 'iad'
+
+[build]
+dockerfile = "oriole/Dockerfile"
+
+[services]
+internal_port = 5432
+protocol = "tcp"
+auto_stop_machines = true
+auto_start_machines = true
+min_machines_running = 0
+max_machines_running = 1
+
+[[services.ports]]
+    port = 5432
+    protocol = "tcp"
+
+
+[[vm]]
+  memory = '2gb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,10 @@ max_machines_running = 1
 [[services.ports]]
     port = 5432
     protocol = "tcp"
+[[services.tcp_checks]]
+  grace_period = '10s'
+  interval = '15s'
+  timeout = '2s'
 
 
 [[vm]]

--- a/oriole/Dockerfile
+++ b/oriole/Dockerfile
@@ -1,9 +1,9 @@
 FROM orioledb/orioledb:latest-pg16 as base
 
-COPY --chown=postgres:postgres postgresql /etc/postgresql
+COPY --chown=postgres:postgres oriole/postgresql /etc/postgresql
 
 ENV PG_CONF=/etc/postgresql/postgresql.conf
-COPY entrypoint-s3.sh /
+COPY oriole/entrypoint-s3.sh /
 ENTRYPOINT ["/entrypoint-s3.sh"]
 
 CMD ["postgres", "-D", "/etc/postgresql"]


### PR DESCRIPTION
This PR adds minimal docs to deploy serverless postgres on fly.io. Here from @kiwicopple's tweet, willing to contribute more and would love to know what's the next milestone in the roadmap for is :)