### PR TITLE
Add tls and mount volume to persist data

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,9 @@ Deploy your app to Fly:
 fly deploy --ha=false
 ```
 
-This command will use the `fly.toml` file in the project directory to configure and deploy the app.
+This command will use the `fly.toml` file in the project directory to configure and deploy the app. It is going to create a single machine and an attached volume.
 
-### Step 4: Allocate an IP address
-
-To make it easier to connect to your Postgres instance, allocate an IP address:
-
-```bash
-fly ips allocate-v6
-```
-
-This command allocates an IPv6 address that you can use to connect to your Postgres instance.
-Note: If you require an IPv4 address and your client doesn't support IPv6, you can allocate a dedicated IPv4 address. However, be aware that this will incur a cost of $2 per month:
-
-```bash
-fly ips allocate-v4
-```
-
+You can now connect to the postgres instance with the host name: <app-name>.fly.dev
 
 ## Roadmap
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,25 +1,28 @@
 app = 'your-serverless-postgres'
-primary_region = 'iad'
+primary_region = 'ewr'
 
 [build]
-dockerfile = "oriole/Dockerfile"
+  dockerfile = 'oriole/Dockerfile'
 
-[services]
-internal_port = 5432
-protocol = "tcp"
-auto_stop_machines = true
-auto_start_machines = true
-min_machines_running = 0
-max_machines_running = 1
-
-[[services.ports]]
+[[services]]
+  protocol = 'tcp'
+  internal_port = 5432
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  [[services.ports]]
+    handlers = ["pg_tls"]
     port = 5432
-    protocol = "tcp"
-[[services.tcp_checks]]
-  grace_period = '10s'
-  interval = '15s'
-  timeout = '2s'
+  [[services.tcp_checks]]
+    grace_period = '10s'
+    interval = '15s'
+    timeout = '2s'
 
+
+[mounts]
+source = 'data'
+destination = "/var/lib/postgresql/"
+initial_size = "1gb"
 
 [[vm]]
   memory = '2gb'

--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
 app = 'your-serverless-postgres'
-primary_region = 'ewr'
+primary_region = 'iad'
 
 [build]
   dockerfile = 'oriole/Dockerfile'
@@ -11,18 +11,17 @@ primary_region = 'ewr'
   auto_start_machines = true
   min_machines_running = 0
   [[services.ports]]
-    handlers = ["pg_tls"]
+    handlers = ['pg_tls']
     port = 5432
   [[services.tcp_checks]]
     grace_period = '10s'
     interval = '15s'
     timeout = '2s'
 
-
 [mounts]
 source = 'data'
-destination = "/var/lib/postgresql/"
-initial_size = "1gb"
+destination = '/var/lib/postgresql/'
+initial_size = '1gb'
 
 [[vm]]
   memory = '2gb'

--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,7 @@ primary_region = 'iad'
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
+  max_machines_running = 1
   [[services.ports]]
     handlers = ['pg_tls']
     port = 5432


### PR DESCRIPTION
This PR fixes the initial issues mentioned in #2.

1. Data is now persisted b/w restarts via a volume mount.
2. Connect externally without being charged for an ip address via the hostname along with tls.
3. Believe auto-start/stop wasn't working because of local proxy so nothing to fix.
4. Now connects with tls.

Will have 5 in a sep PR.